### PR TITLE
fix chage module on python3

### DIFF
--- a/library/chage
+++ b/library/chage
@@ -152,8 +152,8 @@ def main():
     current_shadow = None
     try:
         f = open('/etc/shadow', 'r')
-    except IOError, (errno, strerror):
-        message = "unable to open /etc/shadow, I/O error(%s): %s" % (errno, strerror)
+    except IOError as err:
+        message = "unable to open /etc/shadow, I/O error(%s): %s" % (err.errno, err.strerror)
         module.fail_json(msg=message)
 
     for line in f.readlines():
@@ -191,7 +191,7 @@ def main():
     import re
     date_pattern = re.compile("[0-9]{4}-[0-9]{2}-[0-9]{2}")
 
-    for param_name, flag_name in chage_flags.iteritems():
+    for param_name, flag_name in chage_flags.items():
         desired_value = module.params[param_name]
         desired_cmd_value = desired_value
 


### PR DESCRIPTION
Module fails on python3 as-is.  This fixes that.